### PR TITLE
Extra Standard in der Version 1.4, java.util.Calender -> java.time.Local[Date|Time]

### DIFF
--- a/java/apps/extra-cli/pom.xml
+++ b/java/apps/extra-cli/pom.xml
@@ -27,12 +27,12 @@
 	<parent>
 		<groupId>de.extra-standard</groupId>
 		<artifactId>extra-parent</artifactId>
-		<version>2.0.0</version>
+		<version>3.0.0</version>
 		<relativePath>components/extra-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>extra-cli</artifactId>
-	<version>2.3.0</version>
+	<version>3.0.0</version>
 	<packaging>jar</packaging>
 	<name>extra-cli</name>
 	<description>eXTra Command Line Interface</description>
@@ -46,32 +46,32 @@
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-api</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-configplugin-default</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-responseprocessplugin-sample</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-dataplugin-dbquery</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-dataplugin-simplequery</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-dataplugin-file</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 <!-- 		<dependency>
 			<groupId>de.extra-standard</groupId>
@@ -81,29 +81,29 @@
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-outputplugin-ws</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-outputplugin-wscxf</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-execution-jpa</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-execution-jpa</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 			<scope>test</scope>
 			<type>test-jar</type>
 		</dependency>
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-core</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-cli</groupId>

--- a/java/apps/extra-common-conf/pom.xml
+++ b/java/apps/extra-common-conf/pom.xml
@@ -18,12 +18,12 @@
 	<parent>
 		<groupId>de.extra-standard</groupId>
 		<artifactId>extra-parent</artifactId>
-		<version>2.0.0</version>
+		<version>3.0.0</version>
 		<relativePath />
 	</parent>
 
 	<artifactId>extra-common-conf</artifactId>
-	<version>2.3.0</version>
+	<version>3.0.0</version>
 	<packaging>jar</packaging>
 	<name>extra-common-conf</name>
 	<description>Global and Mandator Configuration for eXTra Client</description>
@@ -36,13 +36,13 @@
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-cli</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-cli</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-execution-jpa</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 			<scope>test</scope>
 			<type>test-jar</type>
 		</dependency>

--- a/java/apps/extra-scenario-sendfetch/pom.xml
+++ b/java/apps/extra-scenario-sendfetch/pom.xml
@@ -18,12 +18,12 @@
 	<parent>
 		<groupId>de.extra-standard</groupId>
 		<artifactId>extra-parent</artifactId>
-		<version>2.0.0</version>
+		<version>3.0.0</version>
 		<relativePath>../../components/extra-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>extra-scenario-sendfetch</artifactId>
-	<version>2.3.0</version>
+	<version>3.0.0</version>
 	<name>extra-scenario-sendfetch</name>
 	<description>eXTra Szenario Send-Fetch (Sende-Hole Betrieb)</description>
 
@@ -31,7 +31,7 @@
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-cli</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 
 		<dependency>
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-execution-jpa</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 			<scope>test</scope>
 			<type>test-jar</type>
 		</dependency>

--- a/java/components/extra-api/pom.xml
+++ b/java/components/extra-api/pom.xml
@@ -26,28 +26,28 @@
 	<parent>
 		<groupId>de.extra-standard</groupId>
 		<artifactId>extra-parent</artifactId>
-		<version>2.0.0</version>
+		<version>3.0.0</version>
 		<relativePath>components/extra-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>extra-api</artifactId>
-	<version>2.3.0</version>
+	<version>3.0.0</version>
 	<packaging>jar</packaging>
 	<name>extra-api</name>
 	<description>eXTra API</description>
 
 	<!-- For KissMDA -->
 	<properties>
-		<kissmda.maven.plugin.version>2.0.0</kissmda.maven.plugin.version>
-		<kissmda.cartridges.simple.java.version>2.0.1</kissmda.cartridges.simple.java.version>
-		<kissmda.extensions.importpacker.version>1.0.0</kissmda.extensions.importpacker.version>
+		<kissmda.maven.plugin.version>2.1.1</kissmda.maven.plugin.version>
+		<kissmda.cartridges.simple.java.version>2.1.1</kissmda.cartridges.simple.java.version>
+		<kissmda.extensions.importpacker.version>2.1.1</kissmda.extensions.importpacker.version>
 	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-schema</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 	</dependencies>
 

--- a/java/components/extra-api/src/main/resources/model/emf/extra-api.uml
+++ b/java/components/extra-api/src/main/resources/model/emf/extra-api.uml
@@ -1096,7 +1096,7 @@
         </ownedTemplateSignature>
         <generalization xmi:id="_17_0_2_7e40267_1380633222332_83966_2370" general="_17_0_2_7e40267_1380633064233_575958_2174"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_17_0_2_1_43601ab_1381782980671_337506_2143" name="Calendar"/>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_17_0_2_1_43601ab_1381782980671_337506_2143" name="DateTime"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="magicdraw_uml_standard_profile_v_0001" name="UML Standard Profile">
       <ownedComment xmi:id="_be00301_1078843546940_242228_131" body="UML Standard Profile contains UML metamodel (metaclasses without properties and associations), StandardProfileL2 and StandardProfileL3 from UML specification, Standard UML stereotypes defined in annex C of UML specification.&#xA;Profile also includes validation suites for UML model correctness and completeness checking, and stereotypes used by MagicDraw internally." annotatedElement="magicdraw_uml_standard_profile_v_0001"/>

--- a/java/components/extra-configplugin-default/pom.xml
+++ b/java/components/extra-configplugin-default/pom.xml
@@ -25,12 +25,12 @@
 	<parent>
 		<groupId>de.extra-standard</groupId>
 		<artifactId>extra-parent</artifactId>
-		<version>2.0.0</version>
+		<version>3.0.0</version>
 		<relativePath>components/extra-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>extra-configplugin-default</artifactId>
-	<version>2.3.0</version>
+	<version>3.0.0</version>
 	<name>extra-configplugin-default</name>
 	<description>Config Plugin Default Implementation</description>
 
@@ -38,13 +38,13 @@
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-api</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-sample</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 		
 		<!-- Java Inject -->

--- a/java/components/extra-core/pom.xml
+++ b/java/components/extra-core/pom.xml
@@ -25,12 +25,12 @@
 	<parent>
 		<groupId>de.extra-standard</groupId>
 		<artifactId>extra-parent</artifactId>
-		<version>2.0.0</version>
+		<version>3.0.0</version>
 		<relativePath>components/extra-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>extra-core</artifactId>
-	<version>2.3.0</version>
+	<version>3.0.0</version>
 	<name>extra-core</name>
 	<description>eXTra Core Components</description>
 
@@ -38,19 +38,19 @@
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-schema</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-api</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-sample</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 
 		<dependency>

--- a/java/components/extra-core/src/main/java/de/extra/client/core/builder/impl/components/TransportHeaderRequestDetailsBuilder.java
+++ b/java/components/extra-core/src/main/java/de/extra/client/core/builder/impl/components/TransportHeaderRequestDetailsBuilder.java
@@ -18,7 +18,6 @@
  */
 package de.extra.client.core.builder.impl.components;
 
-import java.util.GregorianCalendar;
 
 import javax.inject.Named;
 
@@ -33,6 +32,7 @@ import de.drv.dsrv.extrastandard.namespace.components.TextType;
 import de.extra.client.core.builder.IXmlComplexTypeBuilder;
 import de.extrastandard.api.model.content.IExtraProfileConfiguration;
 import de.extrastandard.api.model.content.IInputDataContainer;
+import java.time.LocalDateTime;
 
 /**
  * @author Leonid Potap
@@ -87,7 +87,7 @@ public class TransportHeaderRequestDetailsBuilder implements
 		final String requestIDString = senderData.getRequestId();
 		requestId.setValue(requestIDString);
 		requestDetails.setRequestID(requestId);
-		requestDetails.setTimeStamp(new GregorianCalendar());
+		requestDetails.setTimeStamp(LocalDateTime.now());
 
 		// Controllerinformation
 		requestDetails.setProcedure(requestDetailProcedure);

--- a/java/components/extra-core/src/main/java/de/extra/client/core/builder/impl/plugins/DataSourceSingleInputDataPluginsBuilder.java
+++ b/java/components/extra-core/src/main/java/de/extra/client/core/builder/impl/plugins/DataSourceSingleInputDataPluginsBuilder.java
@@ -18,7 +18,7 @@
  */
 package de.extra.client.core.builder.impl.plugins;
 
-import java.util.GregorianCalendar;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import javax.inject.Named;
@@ -37,6 +37,7 @@ import de.extrastandard.api.model.content.IInputDataContainer;
 import de.extrastandard.api.model.content.IInputDataPluginDescription;
 import de.extrastandard.api.model.content.ISingleContentInputData;
 import de.extrastandard.api.model.content.ISingleInputData;
+import java.time.ZoneId;
 
 /**
  * Erstellt ein Datasource XML Fragment für genau 1 Inputdata
@@ -83,9 +84,9 @@ public class DataSourceSingleInputDataPluginsBuilder extends
 						.getDataContainerCode());
 				// 27.12.2012 Die Semantik des Feldes ist unklar. Ist das
 				// Erstellungsdatum des Files?
-				final GregorianCalendar calenderCreated = new GregorianCalendar();
-				calenderCreated
-						.setTime(dataSourcePluginDescriptor.getCreated());
+				final LocalDateTime calenderCreated = dataSourcePluginDescriptor.getCreated().toInstant()
+                                        .atZone(ZoneId.systemDefault())
+                                        .toLocalDateTime();
 				dataContainer.setCreated(calenderCreated);
 				dataContainer.setEncoding(dataSourcePluginDescriptor
 						.getEncoding());

--- a/java/components/extra-core/src/main/java/de/extra/client/core/model/DataSourcePluginHelper.java
+++ b/java/components/extra-core/src/main/java/de/extra/client/core/model/DataSourcePluginHelper.java
@@ -18,7 +18,7 @@
  */
 package de.extra.client.core.model;
 
-import java.util.GregorianCalendar;
+import java.time.LocalDateTime;
 
 import de.drv.dsrv.extrastandard.namespace.plugins.AbstractPlugInType;
 import de.drv.dsrv.extrastandard.namespace.plugins.DataContainerType;
@@ -39,7 +39,7 @@ public class DataSourcePluginHelper extends PluginHelperBase {
 		// Fuellen des DataContainers
 
 		dataContainer.setEncoding(dataSourcePluginBean.getEncoding());
-		dataContainer.setCreated(new GregorianCalendar());
+		dataContainer.setCreated(LocalDateTime.now());
 		dataContainer.setType(dataSourcePluginBean.getType().toString());
 		dataContainer.setName(dataSourcePluginBean.getName());
 

--- a/java/components/extra-core/src/main/java/de/extra/client/core/plugin/dummies/DummyOutputPlugin.java
+++ b/java/components/extra-core/src/main/java/de/extra/client/core/plugin/dummies/DummyOutputPlugin.java
@@ -18,7 +18,6 @@
  */
 package de.extra.client.core.plugin.dummies;
 
-import java.util.GregorianCalendar;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -45,6 +44,7 @@ import de.extra.client.core.observer.impl.TransportInfoBuilder;
 import de.extrastandard.api.observer.ITransportInfo;
 import de.extrastandard.api.observer.ITransportObserver;
 import de.extrastandard.api.plugin.IOutputPlugin;
+import java.time.LocalDateTime;
 
 @Named("dummyOutputPlugin")
 public class DummyOutputPlugin implements IOutputPlugin {
@@ -95,7 +95,7 @@ public class DummyOutputPlugin implements IOutputPlugin {
 		final ClassifiableIDType idType = new ClassifiableIDType();
 		idType.setValue("42");
 		responseDetailsType.setResponseID(idType);
-		responseDetailsType.setTimeStamp(new GregorianCalendar());
+		responseDetailsType.setTimeStamp(LocalDateTime.now());
 		final ReportType reportType = new ReportType();
 		reportType.setHighestWeight("http://www.extra-standard.de/weight/OK");
 		final FlagType flagType = new FlagType();

--- a/java/components/extra-core/src/main/java/de/extra/client/core/plugin/dummies/DummyQueryDataResponceOutputPlugin.java
+++ b/java/components/extra-core/src/main/java/de/extra/client/core/plugin/dummies/DummyQueryDataResponceOutputPlugin.java
@@ -21,7 +21,7 @@ package de.extra.client.core.plugin.dummies;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
-import java.util.GregorianCalendar;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import javax.activation.DataHandler;
@@ -123,7 +123,7 @@ public class DummyQueryDataResponceOutputPlugin implements IOutputPlugin {
 			final ResponseTransportHeader transportHeader = new ResponseTransportHeader();
 			transportHeader.setTestIndicator(TEST_INDICATOR);
 			final ResponseDetailsType responseDetailsType = new ResponseDetailsType();
-			responseDetailsType.setTimeStamp(new GregorianCalendar());
+			responseDetailsType.setTimeStamp(LocalDateTime.now());
 			final ClassifiableIDType idType = new ClassifiableIDType();
 			idType.setValue("42");
 			responseDetailsType.setResponseID(idType);
@@ -180,7 +180,7 @@ public class DummyQueryDataResponceOutputPlugin implements IOutputPlugin {
 
 				packageResponseDetailsType.setReport(packageReportType);
 				packageResponseDetailsType
-						.setTimeStamp(new GregorianCalendar());
+						.setTimeStamp(LocalDateTime.now());
 				trancportBodyPackage.setPackageHeader(packageHeader);
 				transportBody.getPackage().add(trancportBodyPackage);
 			}

--- a/java/components/extra-dataplugin-dbquery/pom.xml
+++ b/java/components/extra-dataplugin-dbquery/pom.xml
@@ -25,12 +25,12 @@
 	<parent>
 		<groupId>de.extra-standard</groupId>
 		<artifactId>extra-parent</artifactId>
-		<version>2.0.0</version>
+		<version>3.0.0</version>
 		<relativePath>../../components/extra-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>extra-dataplugin-dbquery</artifactId>
-	<version>2.3.0</version>
+	<version>3.0.0</version>
 	<packaging>jar</packaging>
 	<name>extra-dataplugin-dbquery</name>
 	<description>Dataplugin provides query data from the database</description>
@@ -39,25 +39,25 @@
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-api</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-sample</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-execution-jpa</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>			
 		
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-execution-jpa</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 			<scope>test</scope>
 			<type>test-jar</type>
 		</dependency>			

--- a/java/components/extra-dataplugin-file/pom.xml
+++ b/java/components/extra-dataplugin-file/pom.xml
@@ -25,12 +25,12 @@
 	<parent>
 		<groupId>de.extra-standard</groupId>
 		<artifactId>extra-parent</artifactId>
-		<version>2.0.0</version>
+		<version>3.0.0</version>
 		<relativePath>../../components/extra-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>extra-dataplugin-file</artifactId>
-	<version>2.3.0</version>
+	<version>3.0.0</version>
 	<packaging>jar</packaging>
 	<name>extra-dataplugin-file</name>
 	<description>Data Plugin for Filesystem</description>
@@ -39,19 +39,19 @@
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-sample</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>		
 		
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-api</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-schema</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>	
 		
 		<!-- Java Inject -->

--- a/java/components/extra-dataplugin-simplequery/pom.xml
+++ b/java/components/extra-dataplugin-simplequery/pom.xml
@@ -25,12 +25,12 @@
 	<parent>
 		<groupId>de.extra-standard</groupId>
 		<artifactId>extra-parent</artifactId>
-		<version>2.0.0</version>
+		<version>3.0.0</version>
 		<relativePath>../../components/extra-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>extra-dataplugin-simplequery</artifactId>
-	<version>2.3.0</version>
+	<version>3.0.0</version>
 	<name>extra-dataplugin-simplequery</name>
 	<description>Data Plugin for Simple Query with Database</description>
 
@@ -38,13 +38,13 @@
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-api</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-sample</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 
 		<!-- Java Inject -->

--- a/java/components/extra-execution-jpa/pom.xml
+++ b/java/components/extra-execution-jpa/pom.xml
@@ -18,12 +18,12 @@
 	<parent>
 		<groupId>de.extra-standard</groupId>
 		<artifactId>extra-parent</artifactId>
-		<version>2.0.0</version>
+		<version>3.0.0</version>
 		<relativePath>../../components/extra-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>extra-execution-jpa</artifactId>
-	<version>2.3.0</version>
+	<version>3.0.0</version>
 	<packaging>jar</packaging>
 	<name>extra-execution-jpa</name>
 	<description>Execution Persistence Implementierung (JPA)</description>
@@ -32,13 +32,13 @@
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-api</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-sample</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 
 		<dependency>

--- a/java/components/extra-outputplugin-ws/pom.xml
+++ b/java/components/extra-outputplugin-ws/pom.xml
@@ -25,12 +25,12 @@
 	<parent>
 		<groupId>de.extra-standard</groupId>
 		<artifactId>extra-parent</artifactId>
-		<version>2.0.0</version>
+		<version>3.0.0</version>
 		<relativePath>../../components/extra-parent/pom.xml</relativePath>
 	</parent>
 	
 	<artifactId>extra-outputplugin-ws</artifactId>
-	<version>2.3.0</version>
+	<version>3.0.0</version>
 	<packaging>jar</packaging>
 	<name>extra-outputplugin-ws</name>
 	<description>eXTra Outputplugin für Webservices</description>
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-sample</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>jaxb-xjc</artifactId>
@@ -56,7 +56,7 @@
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-api</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 
 		<dependency>

--- a/java/components/extra-outputplugin-wscxf/pom.xml
+++ b/java/components/extra-outputplugin-wscxf/pom.xml
@@ -27,11 +27,11 @@
 	<parent>
 		<groupId>de.extra-standard</groupId>
 		<artifactId>extra-parent</artifactId>
-		<version>2.0.0</version>
+		<version>3.0.0</version>
 	</parent>
 
 	<artifactId>extra-outputplugin-wscxf</artifactId>
-	<version>2.3.0</version>
+	<version>3.0.0</version>
 	<packaging>jar</packaging>
 	<name>extra-outputplugin-wscxf</name>
 	<description>eXTra Outputplugin für Webservices mit Attachments</description>
@@ -45,20 +45,20 @@
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-api</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-schema</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 		
 	    <!-- (23.10.12) wegen JAXB-Versions-Problemen herausgenommen!  -->
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-sample</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>jaxb-xjc</artifactId>

--- a/java/components/extra-parent/pom.xml
+++ b/java/components/extra-parent/pom.xml
@@ -23,7 +23,7 @@
 
 	<groupId>de.extra-standard</groupId>
 	<artifactId>extra-parent</artifactId>
-	<version>2.0.0</version>
+	<version>3.0.0</version>
 	<packaging>pom</packaging>
 
 	<name>extra-parent</name>
@@ -167,6 +167,7 @@
 		<!-- JAXB -->
 		<com.sun.xml.bind.jaxb-impl.version>2.2.5</com.sun.xml.bind.jaxb-impl.version>
 		<com.sun.xml.bind.jaxb-xjc.version>2.2.5</com.sun.xml.bind.jaxb-xjc.version>
+		<com.migesok.jaxb-java-time-adapters.version>1.1.3</com.migesok.jaxb-java-time-adapters.version>
 
 		<!-- CXF -->
 		<org.apache.cxf.version>3.1.6</org.apache.cxf.version>
@@ -257,6 +258,12 @@
 				<groupId>com.sun.xml.bind</groupId>
 				<artifactId>jaxb-xjc</artifactId>
 				<version>${com.sun.xml.bind.jaxb-xjc.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.migesok</groupId>
+				<artifactId>jaxb-java-time-adapters</artifactId>
+				<version>${com.migesok.jaxb-java-time-adapters.version}</version>
 			</dependency>
 
 			<!-- Unit Testing -->

--- a/java/components/extra-responseprocessplugin-sample/pom.xml
+++ b/java/components/extra-responseprocessplugin-sample/pom.xml
@@ -25,12 +25,12 @@
 	<parent>
 		<groupId>de.extra-standard</groupId>
 		<artifactId>extra-parent</artifactId>
-		<version>2.0.0</version>
+		<version>3.0.0</version>
 		<relativePath>../../components/extra-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>extra-responseprocessplugin-sample</artifactId>
-	<version>2.3.0</version>
+	<version>3.0.0</version>
 	<name>extra-responseprocessplugin-sample</name>
 	<description>Responseprocess Plugin Sample</description>
 
@@ -38,19 +38,19 @@
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-api</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-sample</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-schema</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>				
 
 		<dependency>

--- a/java/components/extra-sample/pom.xml
+++ b/java/components/extra-sample/pom.xml
@@ -25,12 +25,12 @@
 	<parent>
 		<groupId>de.extra-standard</groupId>
 		<artifactId>extra-parent</artifactId>
-		<version>2.0.0</version>
+		<version>3.0.0</version>
 		<relativePath>../../components/extra-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>extra-sample</artifactId>
-	<version>2.3.0</version>
+	<version>3.0.0</version>
 	<packaging>jar</packaging>
 	<name>extra-sample</name>
 	<description>eXTra Sample</description>
@@ -39,13 +39,13 @@
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-api</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>de.extra-standard</groupId>
 			<artifactId>extra-schema</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.0</version>
 		</dependency>		
 		
 		<!-- Java Inject -->

--- a/java/components/extra-sample/src/main/java/de/extra/client/core/observer/impl/TransportInfo.java
+++ b/java/components/extra-sample/src/main/java/de/extra/client/core/observer/impl/TransportInfo.java
@@ -18,7 +18,7 @@
  */
 package de.extra.client.core.observer.impl;
 
-import java.util.Calendar;
+import java.time.LocalDateTime;
 
 import de.extrastandard.api.observer.ITransportInfo;
 
@@ -30,7 +30,7 @@ public class TransportInfo implements ITransportInfo {
 
 	private String headerId;
 
-	private Calendar time;
+	private LocalDateTime time;
 
 	private String procedure;
 
@@ -44,7 +44,7 @@ public class TransportInfo implements ITransportInfo {
 	 * @param procedure
 	 * @param application
 	 */
-	public TransportInfo(String headerId, Calendar time, String procedure,
+	public TransportInfo(String headerId, LocalDateTime time, String procedure,
 			String application) {
 		super();
 		this.headerId = headerId;
@@ -75,7 +75,7 @@ public class TransportInfo implements ITransportInfo {
 	 * @see de.extrastandard.api.observer.ITransportInfo#getTime()
 	 */
 	@Override
-	public Calendar getTime() {
+	public LocalDateTime getTime() {
 		return time;
 	}
 
@@ -111,7 +111,7 @@ public class TransportInfo implements ITransportInfo {
 	 * @param time
 	 *            the time to set
 	 */
-	public void setTime(Calendar time) {
+	public void setTime(LocalDateTime time) {
 		this.time = time;
 	}
 

--- a/java/components/extra-schema/pom.xml
+++ b/java/components/extra-schema/pom.xml
@@ -18,12 +18,12 @@
 	<parent>
 		<groupId>de.extra-standard</groupId>
 		<artifactId>extra-parent</artifactId>
-		<version>2.0.0</version>
+		<version>3.0.0</version>
 		<relativePath>../../components/extra-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>extra-schema</artifactId>
-	<version>2.3.0</version>
+	<version>3.0.0</version>
 	<name>extra-schema</name>
 	<description>eXTra Schema for XSD</description>
 
@@ -43,6 +43,11 @@
 		<dependency>
 			<groupId>com.sun.xml.bind</groupId>
 			<artifactId>jaxb-xjc</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.migesok</groupId>
+			<artifactId>jaxb-java-time-adapters</artifactId>
 		</dependency>
 
 		<dependency>

--- a/java/components/extra-schema/src/main/java/de/drv/dsrv/extra/schemaversion/ExtraSchemaVersion.java
+++ b/java/components/extra-schema/src/main/java/de/drv/dsrv/extra/schemaversion/ExtraSchemaVersion.java
@@ -26,7 +26,7 @@ package de.drv.dsrv.extra.schemaversion;
  */
 public enum ExtraSchemaVersion {
 
-	CURRENT_SCHEMA_VERSION("1.3");
+	CURRENT_SCHEMA_VERSION("1.4");
 
 	String version;
 

--- a/java/components/extra-schema/src/main/resources/xsd/eXTra-codelists-1.xsd
+++ b/java/components/extra-schema/src/main/resources/xsd/eXTra-codelists-1.xsd
@@ -4,9 +4,9 @@
     
     @file    eXTra-codelists-1.xsd
     @author  [MS] Michael Schäfer, Statistisches Bundesamt
-    @version 1.3.0
+    @version 1.4.0
     @state   RELEASE
-    @date    2011-09-12
+    @date    2013-10-17
     
     @changed 2009-07-17 1.1 MS - Removed XHTML namespace
     @changed 2010-07-04 1.2 MS + Added EnpointCodeType
@@ -14,6 +14,8 @@
     @changed 2011-06-17 1.2 MS + Added DataTypeCodeType
     @changed 2011-08-22 1.3 MS / Changed 'RepeatResponseRequest' to 'RepeatResponse'
     @changed 2011-09-12 1.3 MS / Set schema version to 1.3
+    @changed 2013-05-14 1.4 MS / Set schema version to '1.4.0'
+    @added   2013-05-14 1.4 MS + ListRequest* and ListResponse* types.
 -->
 <xs:schema
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -21,7 +23,7 @@
     targetNamespace="http://www.extra-standard.de/namespace/codelists/1"
     attributeFormDefault="unqualified"
     elementFormDefault="qualified"
-    version="1.3.0">
+    version="1.4.0">
     
     <!--
         @changed 2009-07-17 MS / Changed base type to xs:anyURI
@@ -291,5 +293,26 @@
             
         </xs:restriction>
     </xs:simpleType>
+    
+    <!-- @created 2013-05-14 MS
+    -->
+    <xs:simpleType name="RequestStatesType">
+        <xs:annotation>
+            <xs:documentation>
+                A list of extensible codes denoting a state during request processing contact endpoint type. 
+                Base values:
+                - http://www.extra-standard.de/requestState/NONE
+                - http://www.extra-standard.de/requestState/AVAILABLE
+                - http://www.extra-standard.de/requestState/FETCHED
+                - http://www.extra-standard.de/requestState/CONFIRMED
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:anyURI">
+            <xs:pattern value="http://www.extra-standard.de/endpoint/(NONE|AVAILABLE|FETCHED|CONFIRMED)(#[a-zA-Z0-9]([.\-][a-zA-Z0-9]+)*)?"/>
+            <xs:pattern value=".+"/>
+        </xs:restriction>
+    </xs:simpleType>
+    
+    
     
 </xs:schema>

--- a/java/components/extra-schema/src/main/resources/xsd/eXTra-components-1.xsd
+++ b/java/components/extra-schema/src/main/resources/xsd/eXTra-components-1.xsd
@@ -4,17 +4,21 @@
     
     @file    eXTra-components-1.xsd
     @author  [MS] Michael Schäfer, Statistisches Bundesamt
-    @version 1.3.0
+    @version 1.4.0
     @state   RELEASE
-    @date    2011-09-12
+    @date    2013-10-17
     
     @changed 2009-07-17 1.1 MS - Removed XHTML namespace
-    @changed 2010-02-21 MS + Added version '1.2'
-    @changed 2010-07-04 MS / Restricted version identifier to '1.2'
-    @changed 2010-07-12 MS / Made 'ResponseDetailsType' non-abstract
-    @changed 2011-06-17 MS / Changed type of element 'DataType' to 'xcode:DataTypeCodeType'
-    @changed 2010-09-12 1.3 MS - Added values '1.0', 1.1', 1.3'
+    @changed 2010-02-21 1.2 MS + Added version '1.2'
+    @changed 2010-07-04 1.2 MS / Restricted version identifier to '1.2'
+    @changed 2010-07-12 1.2 MS / Made 'ResponseDetailsType' non-abstract
+    @changed 2011-06-17 1.3 MS / Changed type of element 'DataType' to 'xcode:DataTypeCodeType'
+    @changed 2011-09-12 1.3 MS - Set version identifiers to '1.0', 1.1', 1.3'
     @changed 2011-09-12 1.3 MS / Set schema version to 1.3
+    @changed 2013-09-06 1.4 MS / Added xmime NS and xmime:expectedContentTypes
+                                 on Base64CharSequenceType
+    @changed 2013-10-17 1.4 MS / Set schema version to 1.4
+                               + Added version identifier '1.4'
     
 -->
 <xs:schema
@@ -24,10 +28,9 @@
     xmlns:xplg="http://www.extra-standard.de/namespace/plugins/1"
     xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns:xmime="http://www.w3.org/2005/05/xmlmime"
-    attributeFormDefault="unqualified"
+    xmlns:xmime="http://www.w3.org/2005/05/xmlmime"    attributeFormDefault="unqualified"
     elementFormDefault="qualified"
-    version="1.3.0">
+    version="1.4.0">
     
     <!-- Import eXTra code lists -->
     
@@ -53,6 +56,8 @@
          @changed 2010-02-21 1.2 MS + Added value '1.2'
          @changed 2010-07-04 1.2 MS - Removed values < '1.2'
          @changed 2010-09-12 1.3 MS - Added values '1.0', 1.1', 1.3'
+         @changed 2010-10-17 1.4 MS + Added value '1.4'
+
     -->
     <xs:simpleType name="SupportedVersionsType">
         <xs:restriction base="AbstractVersionType">
@@ -66,6 +71,7 @@
             <xs:enumeration value="1.1"/>
             <xs:enumeration value="1.2"/>
             <xs:enumeration value="1.3"/>
+            <xs:enumeration value="1.4"/>
         </xs:restriction>
     </xs:simpleType>
     
@@ -254,9 +260,12 @@
         <xs:attribute name="weight" type="xcode:WeightCodeType" use="required"/>
     </xs:complexType>
     
+    <!-- @changed 2013-09-06 1.4 MS / Added attribute xmime:expectedContentTypes
+    -->
     <xs:complexType name="Base64CharSequenceType">
         <xs:simpleContent>
-            <xs:extension base="xs:base64Binary" xmime:expectedContentTypes="application/octet-stream"/>
+            <xs:extension base="xs:base64Binary"
+                xmime:expectedContentTypes="application/octet-stream"/>
         </xs:simpleContent>
     </xs:complexType>
     

--- a/java/components/extra-schema/src/main/resources/xsd/eXTra-error-1.xsd
+++ b/java/components/extra-schema/src/main/resources/xsd/eXTra-error-1.xsd
@@ -66,7 +66,5 @@
     
     <!-- @since 1.0 MS -->
     <xs:element name="ExtraError" type="ExtraErrorType"/>
-    <!-- Workaround FehlermeldungMapping -->
-    <xs:element name="XMLError" type="ExtraErrorType"/>
         
 </xs:schema>

--- a/java/components/extra-schema/src/main/resources/xsd/eXTra-logging-1.xsd
+++ b/java/components/extra-schema/src/main/resources/xsd/eXTra-logging-1.xsd
@@ -4,13 +4,14 @@
     
     @file    eXTra-logging-1.xsd
     @author  Michael Schäfer, Statistisches Bundesamt
-    @version 1.3.0
+    @version 1.4.0
     @state   RELEASE
     @date    2011-09-12
     
     @changed 2009-07-17 1.1 MS - Removed XHTML namespace
     @changed 2009-07-17 1.2 MS / Updated version identifier
     @changed 2011-09-12 1.3 MS / Set schema version to 1.3
+    @changed 2013-10-17 1.4 MS / Set schema version to 1.4
     
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
@@ -20,7 +21,7 @@
     targetNamespace="http://www.extra-standard.de/namespace/logging/1"
     attributeFormDefault="unqualified"
     elementFormDefault="qualified"
-    version="1.3.0">
+    version="1.4.0">
 
     <!-- Import eXTra code lists -->
     

--- a/java/components/extra-schema/src/main/resources/xsd/eXTra-messages-1.xsd
+++ b/java/components/extra-schema/src/main/resources/xsd/eXTra-messages-1.xsd
@@ -4,9 +4,9 @@
     
     @file    eXTra-messages-1.xsd
     @author  [MS] Michael Schäfer, Statistisches Bundesamt
-    @version 1.3.0
+    @version 1.4.0
     @state   RELEASE
-    @date    2011-10-18
+    @date    2013-10-21
     
     @changed 2009-10-30 1.1 MS + Added aribute 'event' to AbstractArgumentType,
                                + Added version identifier '1.1'
@@ -38,7 +38,28 @@
                                / DataRequestArgumentType: Element 'Argument' is optional
                                / StatusRequestArgumentType: Element 'Argument' is optional
                                / Extended version attributes to allow older versions.
-                                 
+    @changed 2013-05-14 1.4 MS / Set schema version to '1.4.0'
+    @added   2013-05-14 1.4 MS + ListRequest* and ListResponse* types.
+    @changed 2013-05-24 1.4 MS / Attribute 'state' of ListRequest converted to argument
+                               / Attribute 'state' of ListResponse converted to property
+                               + Added attribute 'order' to ListRequest
+    @changed 2013-09-06 1.4 MS + Argument 'state' added to DataRequest
+                               + Added attribute 'order' to DataRequest
+                               + Added propery 'ExpectedDataSize' to ListResponse
+                               + Added type ListResponsePropertyNamesType
+    @changed 2013-10-14 1.4 MS + Added 'Request*' properties to align property set with that of
+                                 DataRequestPropertyNamesType
+                               / Renamed prop ExceptedDataSize to PayloadSize
+                               / Corrected URI to refer to 'requestState' instead of 'endpoint'
+    @changed 2013-10-21 1.4 MS / Corrected property set mismatch bewtween DataRequestPropertyNamesType
+                                 and ListRequestPropertyNamesType
+    @changed 2014-01-30 1.4 MS + Added attribute 'order' to StatusRequestArgumentType
+    @changed 2014-02-07 1.4 MS + Added version identifier '1.1' to StatusRequestType
+    @changed 2014-05-28 1.4 MS + Element 'ListOfStatusResponse/StatusResponse', cardinality
+                                 changed from 1..1 to 0..unbounded
+    @changed 2014-05-28 1.4 MS + Element 'ListOfStatusResponse/StatusResponse/Property', cardinality
+                                 changed from 1..1 to 1..unbounded
+
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:xmsg="http://www.extra-standard.de/namespace/message/1"
@@ -46,31 +67,8 @@
     targetNamespace="http://www.extra-standard.de/namespace/message/1"
     attributeFormDefault="unqualified"
     elementFormDefault="qualified"
-    version="1.3.0"
+    version="1.4.0"
     >
-
-    <!-- Abstract base types -->
-
-    <!-- AbstractMessageType
-        The abstract base type of any type that represents a message
-        
-        @changed 2009-10-30 1.1 MS + Added version identifier '1.1'
-        @changed 2010-02-21 1.2 MS + Added version identifier '1.2'
-        @deleted 2010-07-04 1.2 MS -
-            @{code %
-            <xs:complexType name="AbstractMessageType" abstract="true">
-                <xs:attribute name="version" use="required">
-                    <xs:simpleType>
-                        <xs:restriction base="xs:string">
-                            <xs:enumeration value="1.0"/>
-                            <xs:enumeration value="1.1"/>
-                            <xs:enumeration value="1.2"/>
-                        </xs:restriction>
-                    </xs:simpleType>
-                </xs:attribute>
-            </xs:complexType>
-            %}
-    -->
 
     <!-- ListOfConfirmationOfReceiptType
         Represents a list of messages for confirming that data has been received succesfully
@@ -171,7 +169,8 @@
          Represents a message for requesting the result of some business
          process that was triggered by a previous message
          
-         @changed 2011-08-05 1.1 MS / Set version identifier to '1.2'
+         @changed 2011-08-05 1.1 MS / Added version identifier '1.2'
+         @changed 2011-09-06 1.1 MS / Added version identifier '1.3'
          
     -->
     <xs:complexType name="DataRequestType">
@@ -184,6 +183,7 @@
                     <xs:enumeration value="1.0" />
                     <xs:enumeration value="1.1" />
                     <xs:enumeration value="1.2" />
+                    <xs:enumeration value="1.3" />
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
@@ -214,26 +214,32 @@
     <!-- DataRequestArgumentType
         Defines a concrete type for arguments of a data request query, restricting
         argument names to those enumerated in  xs:string
+        
+        @changed 2013-09-06 1.4 MS + Added 'order' attribute
     -->
     <xs:complexType name="DataRequestArgumentType">
         <xs:complexContent>
             <xs:extension base="AbstractArgumentType">
                 <xs:attribute name="property" type="DataRequestPropertyNamesType" use="required" />
+                <xs:attribute name="order" type="SortingOrderType" use="optional" default="UNDEFINED"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
 
     <!-- DataRequestPropertyNamesType
         The names of the properties that may appear in a data request query.
-        The names must consitute a subset (in XSD terms: a restriction) of the
+        The names must consitute a subset (in XSD terms: restriction) of the
         names defined in the type PropertyNamesType.
         
-        @changed 2011-08-04 1.3 MS / Added Layer value to DataRequestPropertyNamesType
+        @changed 2011-08-04 1.3 MS + Added value 'Layer'
+        @changed 2013-05-24 1.4 MS / Rearranged prop names in alphabetical order
+        @changed 2013-09-06 1.4 MS + Added 'State' property
+        @changed 2013-10-21 1.4 MS / Set properties to match with ListRequestPropertyNamesType
         
     -->
     <xs:simpleType name="DataRequestPropertyNamesType">
         <xs:restriction base="PropertyNamesType">
-            <xs:pattern value="http://www.extra-standard.de/property/(SenderID|ReceiverID|Procedure|DataType|ResponseID|ResponseCreationTimeStamp|ResponseFileName|Layer)"/>
+            <xs:pattern value="http://www.extra-standard.de/property/(DataType|Layer|Procedure|ReceiverID|RequestCreationTimeStamp|RequestFileName|RequestID|ResponseCreationTimeStamp|ResponseFileName|ResponseID|SenderID|State)"/>
             <xs:pattern value=".+"/>
             <!--
             @deleted 2010-07-04 1.2 MS -
@@ -255,7 +261,9 @@
          ======================
     -->
 
-    <!-- @created 2011-05-08 1.3 MS -->
+    <!-- @created 2011-05-08 1.3 MS 
+         @changed 2014-02-07 1.4 MS + Added version identifier '1.1'
+    -->
     <xs:complexType name="StatusRequestType">
         <xs:sequence>
             <xs:element name="Query" type="StatusRequestQueryType" />
@@ -265,6 +273,7 @@
             <xs:simpleType>
                 <xs:restriction base="xs:string">
                     <xs:enumeration value="1.0" />
+                    <xs:enumeration value="1.1" />
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
@@ -286,12 +295,13 @@
         Defines a concrete type for arguments of a data request query, restricting
         argument names to those enumerated in  xs:string
         @created 2011-05-08 1.3 MS
+        @changed 2014-01-30 1.4 MS + Added 'order' attribute
     -->
     <xs:complexType name="StatusRequestArgumentType">
         <xs:complexContent>
             <xs:extension base="AbstractArgumentType">
-                <xs:attribute name="property" type="StatusRequestPropertyNamesType" use="required"
-                 />
+                <xs:attribute name="property" type="StatusRequestPropertyNamesType" use="required"/>
+                <xs:attribute name="order" type="SortingOrderType" use="optional" default="UNDEFINED"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -301,11 +311,12 @@
         The names must consitute a subset (in XSD terms: a restriction) of the
         names defined in the type PropertyNamesType.
         
-        @changed 2011-078-22 1.3.0 MS Allowed specification of abritrary URIs
+        @changed 2011-07-22 1.3 MS / Allowed specification of abritrary URIs
+        @changed 2013-05-24 1.4 MS / Rearranged prop names in alphabetical order
     -->
     <xs:simpleType name="StatusRequestPropertyNamesType">
         <xs:restriction base="PropertyNamesType">
-            <xs:pattern value="http://www.extra-standard.de/property/(SenderID|ReceiverID|Procedure|DataType|RequestID|RequestCreationTimeStamp|RequestFileName|ResponseID|ResponseCreationTimeStamp|ResponseFileName|Layer)"/>
+            <xs:pattern value="http://www.extra-standard.de/property/(DataType|Layer|Procedure|ReceiverID|RequestCreationTimeStamp|RequestFileName|RequestID|ResponseCreationTimeStamp|ResponseFileName|ResponseID|SenderID)"/>
             <xs:pattern value=".+"/>
             <!--
             @deleted 2010-07-04 1.2 MS -
@@ -467,10 +478,10 @@
     <!-- @created 2011-05-08 1.3 MS -->
     <xs:complexType name="ListOfStatusResponseType">
         <xs:sequence>
-            <xs:element name="StatusResponse">
+            <xs:element name="StatusResponse" minOccurs="0" maxOccurs="unbounded">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element name="Property" type="StatusResponsePropertyType" />
+                        <xs:element name="Property" type="StatusResponsePropertyType" maxOccurs="unbounded"/>
                         <xs:element name="Trace" type="TraceType" />
                     </xs:sequence>
                 </xs:complexType>
@@ -485,6 +496,134 @@
         </xs:attribute>
     </xs:complexType>
 
+    <!-- ======================
+         Message: ListRequest
+         ======================
+    -->
+    
+    <!--
+        @created 2013-05-10 1.4 MS
+    -->
+    <xs:complexType name="ListRequestType">
+        <xs:sequence>
+            <xs:element name="Query" type="ListRequestQueryType" />
+            <xs:element name="Control" type="ControlType" minOccurs="0" />
+        </xs:sequence>
+        <xs:attribute name="version" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="1.0" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    
+    <!-- 
+        Represents a status request query that selects requested objects by certain
+        criteria specified by argument elements.
+        
+        @created 2013-05-10 1.4 MS
+    -->
+    <xs:complexType name="ListRequestQueryType">
+        <xs:sequence>
+            <xs:element name="Argument" type="ListRequestArgumentType"
+                minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+    
+    <!--
+        Defines a concrete type for arguments of a data request query, restricting
+        argument names to those enumerated in  xs:string
+        
+        @created 2013-05-10 1.4 MS
+        @changed 2013-05-24 1.4 MS - Removed 'state' atrribute
+                                   + Added 'order' attribute
+    -->
+    <xs:complexType name="ListRequestArgumentType">
+        <xs:complexContent>
+            <xs:extension base="AbstractArgumentType">
+                <xs:attribute name="property" type="ListRequestPropertyNamesType" use="required"/>
+                <xs:attribute name="order" type="SortingOrderType" use="optional" default="UNDEFINED"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    
+    <!-- 
+        The names of the arguments that may appear in a list request query.
+        The names must consitute a subset (in XSD terms: a restriction) of the
+        names defined in the type PropertyNamesType.
+        
+        @created 2013-05-10 1.4 MS
+        @changed 2013-05-24 1.4 MS + Added 'State' property
+                                   / Rearranged prop names in alphabetical order
+        @changed 2013-10-14 1.4 MS + Added 'Request*' properties to align property set with that of
+                                     DataRequestPropertyNamesType
+    -->
+    <xs:simpleType name="ListRequestPropertyNamesType">
+        <xs:restriction base="PropertyNamesType">
+            <xs:pattern value="http://www.extra-standard.de/property/(DataType|Layer|Procedure|ReceiverID|RequestCreationTimeStamp|RequestFileName|RequestID|ResponseCreationTimeStamp|ResponseFileName|ResponseID|SenderID|State)"/>
+            <xs:pattern value=".+"/>
+        </xs:restriction>
+    </xs:simpleType>
+    
+    <!-- 
+        The names of the properties that may appear in a list response.
+        The names must consitute a subset (in XSD terms: a restriction) of the
+        names defined in the type PropertyNamesType.
+        
+        @created 2013-09-06 1.4 MS
+        @changed 2013-10-14 1.4 MS / Renamed prop ExceptedDataSize to PayloadSize
+    -->
+    <xs:simpleType name="ListResponsePropertyNamesType">
+        <xs:restriction base="PropertyNamesType">
+            <xs:pattern value="http://www.extra-standard.de/property/(DataType|PayloadSize|Procedure|ReceiverID|RequestCreationTimeStamp|RequestFileName|RequestID|ResponseCreationTimeStamp|ResponseFileName|ResponseID|SenderID|State)"/>
+            <xs:pattern value=".+"/>
+        </xs:restriction>
+    </xs:simpleType>
+    
+    <!-- ======================
+         Message: ListResponse
+         ======================
+    -->
+    
+    <!--
+        @created 2013-05-10 1.4 MS
+    -->
+    <xs:complexType name="ListResponseType">
+        <xs:sequence>
+            <xs:element name="Entry" type="ListResponseEntryType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="version" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="1.0" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    
+    <!--
+        @created 2013-05-10 1.4 MS
+    -->
+    <xs:complexType name="ListResponseEntryType">
+        <xs:sequence>
+            <xs:element name="Property" type="ListResponsePropertyType" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    
+    <!--
+        @created 2013-05-10 1.4 MS
+        @changed 2013-05-24 1.4 MS - Removed 'state' atrribute
+        @changed 2013-09-06 1.4 MS - Changed type of attr 'name' to ListResponsePropertyNamesType
+    -->
+    <xs:complexType name="ListResponsePropertyType">
+        <xs:sequence>
+            <xs:element name="Value" type="ValueType" />
+        </xs:sequence>
+        <xs:attribute name="name" type="ListResponsePropertyNamesType" use="required" />
+        <xs:attribute name="type" type="XSDPrefixedTypeCodes" default="xs:string" />
+    </xs:complexType>
+    
     <!-- ============
          Common types
          ============
@@ -518,8 +657,7 @@
             <xs:element name="IN" type="OperandSetType"/>
         </xs:choice>
         <xs:attribute name="type" type="XSDPrefixedTypeCodes" default="xs:string" />
-        <xs:attribute name="event" type="EventNamesType"
-            default="http://www.extra-standard.de/event/Default" />
+        <xs:attribute name="event" type="EventNamesType" default="http://www.extra-standard.de/event/Default" />
     </xs:complexType>
 
     <!-- OperandSetType
@@ -567,10 +705,13 @@
 
     <!--
         @changed 2011-06-17 1.2 MS + Added value 'Layer'
+        @changed 2013-05-24 1.4 MS + Added value 'State'
+                                   / Rearranged prop names in alphabetical order
+        @changed 2013-09-06 1.4 MS + Added value 'ExpectedDataSize'
     -->
     <xs:simpleType name="PropertyNamesType">
         <xs:restriction base="xs:anyURI">
-            <xs:pattern value="http://www.extra-standard.de/property/(SenderID|ReceiverID|Procedure|DataType|RequestID|RequestCreationTimeStamp|RequestFileName|ResponseID|ResponseCreationTimeStamp|ResponseFileName|Layer)"/>
+            <xs:pattern value="http://www.extra-standard.de/property/(DataType|ExpectedDataSize|Layer|Procedure|ReceiverID|RequestCreationTimeStamp|RequestFileName|RequestID|ResponseCreationTimeStamp|ResponseFileName|ResponseID|SenderID|State)"/>
             <xs:pattern value=".+"/>
             <!--
             @deleted 2010-07-04 1.2 MS -
@@ -586,6 +727,7 @@
             <xs:enumeration value="http://www.extra-standard.de/property/ResponseCreationTimeStamp" />
             <xs:enumeration value="http://www.extra-standard.de/property/ResponseFileName" />
             <xs:enumeration value="http://www.extra-standard.de/property/Layer" />
+            %}
             -->
         </xs:restriction>
     </xs:simpleType>
@@ -601,6 +743,27 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <!--
+        @created 2013-05-14 1.4 MS
+        @changed 2013-10-14 1.4 MS / Corrected URI to refer to 'requestState' instead of 'endpoint'
+    -->
+    <xs:simpleType name="RequestStatesType">
+        <xs:annotation>
+            <xs:documentation>
+                A list of extensible codes denoting a state during request processing contact endpoint type. 
+                Base values:
+                - http://www.extra-standard.de/requestState/NONE
+                - http://www.extra-standard.de/requestState/AVAILABLE
+                - http://www.extra-standard.de/requestState/FETCHED
+                - http://www.extra-standard.de/requestState/CONFIRMED
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:anyURI">
+            <xs:pattern value="http://www.extra-standard.de/requestState/(NONE|AVAILABLE|FETCHED|CONFIRMED)(#[a-zA-Z0-9]([.\-][a-zA-Z0-9]+)*)?"/>
+            <xs:pattern value=".+"/>
+        </xs:restriction>
+    </xs:simpleType>
+    
     <xs:complexType name="ValueType">
         <xs:simpleContent>
             <xs:extension base="xs:string" />
@@ -647,7 +810,20 @@
             <xs:pattern value="[0-9]*[1-9][0-9]*[BKMG]" />
         </xs:restriction>
     </xs:simpleType>
-
+    
+    <!--
+        Defines a type for specifiying the sorting order on queriy arguments
+        
+        Examples: A, ASC, ASCENDING, D, DESC, DESCENDING.
+        
+        @created 2013-05-24 MS 
+    -->
+    <xs:simpleType name="SortingOrderType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="A|ASC|ASCENDING|D|DESC|DESCENDING|U|UNDEF|UNDEFINED" />
+        </xs:restriction>
+    </xs:simpleType>
+    
     <xs:simpleType name="XSDPrefixedTypeCodes">
         <xs:annotation>
             <xs:documentation> A list of prefixed XSD atomic type names </xs:documentation>
@@ -741,5 +917,11 @@
     <!-- @created 2011-05-08 1.3 MS -->
     <xs:element name="ListOfStatusResponse" type="ListOfStatusResponseType" />
 
-
+    <!-- @created 2013-05-10 1.3 MS -->
+    <xs:element name="ListRequest" type="ListRequestType" />
+    
+    <!-- @created 2013-05-10 1.3 MS -->
+    <xs:element name="ListResponse" type="ListResponseType" />
+    
+    
 </xs:schema>

--- a/java/components/extra-schema/src/main/resources/xsd/eXTra-plugins-1.xsd
+++ b/java/components/extra-schema/src/main/resources/xsd/eXTra-plugins-1.xsd
@@ -4,11 +4,12 @@
     
     @file    eXTra-plugins-1.xsd
     @author  [MS] Michael Schäfer, Statistisches Bundesamt
-    @version 1.2.0
+    @version 1.4.0
     @state   RELEASE
-    @date    2011-09-12
+    @date    2013-10-21
     
     @changed 2011-09-12 1.3 MS / Set @state to RELEASE
+    @changed 2013-10-21 1.4 MS / Set schema version to 1.4.0
     
 -->
 <xs:schema
@@ -19,7 +20,7 @@
     targetNamespace="http://www.extra-standard.de/namespace/plugins/1"
     attributeFormDefault="unqualified"
     elementFormDefault="qualified"
-    version="1.2.0">
+    version="1.4.0">
 
     <!-- Import of code list declarations -->
     

--- a/java/components/extra-schema/src/main/resources/xsd/eXTra-request-1.xsd
+++ b/java/components/extra-schema/src/main/resources/xsd/eXTra-request-1.xsd
@@ -4,9 +4,9 @@
     
     @file    eXTra-request-1.xsd
     @author  Michael Schäfer, Statistisches Bundesamt
-    @version 1.3.0
+    @version 1.4.0
     @state   RELEASE
-    @date    2011-09-12
+    @date    2013-10-17
     
     @changed 2009-05-05 MS + Added support for TransformedData
     @changed 2009-07-17 MS - Removed XHTML namespace
@@ -14,6 +14,7 @@
     @changed 2011-06-17 MS + Added root element 'Transport' 
                            / Deprecated root element 'XMLTransport'
     @changed 2011-09-12 1.3 MS / Set schema version to 1.3
+    @changed 2013-10-17 1.4 MS / Set schema version to 1.4
                            
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -25,7 +26,7 @@
     targetNamespace="http://www.extra-standard.de/namespace/request/1"
     attributeFormDefault="unqualified"
     elementFormDefault="qualified"
-    version="1.3.0"
+    version="1.4.0"
     >
 
     <!-- Import shared element declarations and type declarations -->
@@ -45,7 +46,15 @@
             <xs:extension base="xcpt:RootElementType">
                 <xs:sequence minOccurs="1" maxOccurs="1">
                     <xs:element ref="TransportHeader" minOccurs="1" maxOccurs="1"/>
-                    <xs:element ref="TransportPlugIns" minOccurs="0" maxOccurs="1"/>
+                    <xs:element ref="TransportPlugIns" minOccurs="0" maxOccurs="1">
+<!--                        <xs:annotation>
+                            <xs:appinfo>
+                                <xprof:profilable xmlns:xprof="http://www.extra-standard.de/namespace/profile/1">
+                                    <xprof:cardinality required="true" optional="true" forbidden="true"/>
+                                </xprof:profilable>
+                            </xs:appinfo>
+                        </xs:annotation>
+-->                    </xs:element>
                     <xs:element ref="TransportBody" minOccurs="1" maxOccurs="1"/>
                     <xs:element ref="xlog:Logging" minOccurs="0" maxOccurs="1"/>
                     <xs:element ref="xcpt:Signatures" minOccurs="0" maxOccurs="1"/>

--- a/java/components/extra-schema/src/main/resources/xsd/eXTra-response-1.xsd
+++ b/java/components/extra-schema/src/main/resources/xsd/eXTra-response-1.xsd
@@ -4,15 +4,16 @@
     
     @file    eXTra-response-1.xsd
     @author  Michael Schäfer, Statistisches Bundesamt
-    @version 1.3.0
+    @version 1.4.0
     @state   RELEASE
-    @date    2011-09-12
+    @date    2013-10-17
     
     @changed 2009-05-05 MS + Added support for TransformedData
     @changed 2009-07-17 MS - Removed XHTML namespace
     @changed 2011-06-17 MS + Added root element 'Transport'
                            / Deprecated root element 'XMLTransport'
     @changed 2011-09-12 1.3 MS / Set schema version to 1.3
+    @changed 2013-10-17 1.4 MS / Set schema version to 1.4
                            
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -24,7 +25,7 @@
     targetNamespace="http://www.extra-standard.de/namespace/response/1"
     attributeFormDefault="unqualified"
     elementFormDefault="qualified"
-    version="1.3.0"
+    version="1.4.0"
     >
     
     <!-- Import shared element declarations and type declarations -->

--- a/java/components/extra-schema/src/main/xjb/binding-message.xjb
+++ b/java/components/extra-schema/src/main/xjb/binding-message.xjb
@@ -96,6 +96,30 @@
     	<jxb:class name="ListOfStatusResponse"/>
 	</jxb:bindings> 
 
+	<jxb:bindings schemaLocation="../resources/xsd/eXTra-messages-1.xsd" node="//xs:complexType[@name='ListRequestType']">
+    	<jxb:class name="ListRequest"/>
+	</jxb:bindings> 
+
+	<jxb:bindings schemaLocation="../resources/xsd/eXTra-messages-1.xsd" node="//xs:complexType[@name='ListRequestQueryType']">
+    	<jxb:class name="ListRequestQuery"/>
+	</jxb:bindings> 
+
+	<jxb:bindings schemaLocation="../resources/xsd/eXTra-messages-1.xsd" node="//xs:complexType[@name='ListRequestArgumentType']">
+    	<jxb:class name="ListRequestArgument"/>
+	</jxb:bindings> 
+
+	<jxb:bindings schemaLocation="../resources/xsd/eXTra-messages-1.xsd" node="//xs:complexType[@name='ListResponseType']">
+    	<jxb:class name="ListResponse"/>
+	</jxb:bindings> 
+
+	<jxb:bindings schemaLocation="../resources/xsd/eXTra-messages-1.xsd" node="//xs:complexType[@name='ListResponseEntryType']">
+    	<jxb:class name="ListResponseEntry"/>
+	</jxb:bindings> 
+
+	<jxb:bindings schemaLocation="../resources/xsd/eXTra-messages-1.xsd" node="//xs:complexType[@name='ListResponsePropertyType']">
+    	<jxb:class name="ListResponseProperty"/>
+	</jxb:bindings> 
+
 	<jxb:bindings schemaLocation="../resources/xsd/eXTra-messages-1.xsd" node="//xs:complexType[@name='AbstractArgumentType']">
     	<jxb:class name="AbstractArgument"/>
 	</jxb:bindings> 

--- a/java/components/extra-schema/src/main/xjb/binding-request.xjb
+++ b/java/components/extra-schema/src/main/xjb/binding-request.xjb
@@ -8,7 +8,7 @@
     version="2.1">
     
    	
-   	<jxb:bindings schemaLocation="../resources/xsd/eXTra-request-1.xsd" node="/xs:schema">
+  	<jxb:bindings schemaLocation="../resources/xsd/eXTra-request-1.xsd" node="/xs:schema">
         <jxb:schemaBindings>
             <jxb:package name="de.drv.dsrv.extrastandard.namespace.request"/>
         </jxb:schemaBindings>

--- a/java/components/extra-schema/src/main/xjb/binding-response.xjb
+++ b/java/components/extra-schema/src/main/xjb/binding-response.xjb
@@ -7,17 +7,14 @@
     jxb:extensionBindingPrefixes="xjc annox"
     version="2.1">
     
-    <jxb:globalBindings>
-        <jxb:javaType name="java.util.Calendar" xmlType="xs:dateTime"
-            parseMethod="javax.xml.bind.DatatypeConverter.parseDateTime"
-            printMethod="javax.xml.bind.DatatypeConverter.printDateTime" />
-        <jxb:javaType name="java.util.Calendar" xmlType="xs:date"
-            parseMethod="javax.xml.bind.DatatypeConverter.parseDate"
-            printMethod="javax.xml.bind.DatatypeConverter.printDate" />
-        <jxb:javaType name="java.util.Calendar" xmlType="xs:time"
-            parseMethod="javax.xml.bind.DatatypeConverter.parseTime"
-            printMethod="javax.xml.bind.DatatypeConverter.printTime" />
-    </jxb:globalBindings> 
+        <jxb:globalBindings>
+            <xjc:javaType name="java.time.LocalDate" xmlType="xs:date"
+                          adapter="com.migesok.jaxb.adapter.javatime.LocalDateXmlAdapter" />
+            <xjc:javaType name="java.time.LocalDateTime" xmlType="xs:dateTime"
+                          adapter="com.migesok.jaxb.adapter.javatime.LocalDateTimeXmlAdapter" />
+            <xjc:javaType name="java.time.LocalTime" xmlType="xs:time"
+                          adapter="com.migesok.jaxb.adapter.javatime.LocalTimeXmlAdapter" />
+        </jxb:globalBindings>
     
   	<jxb:bindings schemaLocation="../resources/xsd/eXTra-response-1.xsd" node="/xs:schema">
         <jxb:schemaBindings>

--- a/java/components/extra-schema/src/test/java/de/drv/dsrv/extra/marshaller/impl/ExtraUnmarschallerTest.java
+++ b/java/components/extra-schema/src/test/java/de/drv/dsrv/extra/marshaller/impl/ExtraUnmarschallerTest.java
@@ -67,7 +67,7 @@ public class ExtraUnmarschallerTest {
 		}
 	}
 
-	private final String validTestRequest = "<xreq:Transport xmlns:xcpt=\"http://www.extra-standard.de/namespace/components/1\" xmlns:xreq=\"http://www.extra-standard.de/namespace/request/1\" xmlns:xenc=\"http://www.w3.org/2001/04/xmlenc#\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:xlog=\"http://www.extra-standard.de/namespace/logging/1\" xmlns:xres=\"http://www.extra-standard.de/namespace/response/1\" xmlns:xplg=\"http://www.extra-standard.de/namespace/plugins/1\" xmlns:xmsg=\"http://www.extra-standard.de/namespace/message/1\" xmlns:xsrv=\"http://www.extra-standard.de/namespace/service/1\" version=\"1.3\" profile=\"http://code.google.com/p/extra-standard/profile/1\">\r\n"
+	private final String validTestRequest = "<xreq:Transport xmlns:xcpt=\"http://www.extra-standard.de/namespace/components/1\" xmlns:xreq=\"http://www.extra-standard.de/namespace/request/1\" xmlns:xenc=\"http://www.w3.org/2001/04/xmlenc#\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:xlog=\"http://www.extra-standard.de/namespace/logging/1\" xmlns:xres=\"http://www.extra-standard.de/namespace/response/1\" xmlns:xplg=\"http://www.extra-standard.de/namespace/plugins/1\" xmlns:xmsg=\"http://www.extra-standard.de/namespace/message/1\" xmlns:xsrv=\"http://www.extra-standard.de/namespace/service/1\" version=\"1.4\" profile=\"http://code.google.com/p/extra-standard/profile/1\">\r\n"
 			+ "    <xreq:TransportHeader>\r\n"
 			+ "        <xcpt:TestIndicator>http://www.extra-standard.de/test/NONE</xcpt:TestIndicator>\r\n"
 			+ "        <xcpt:Sender>\r\n"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -25,12 +25,12 @@
 	<parent>
 		<groupId>de.extra-standard</groupId>
 		<artifactId>extra-parent</artifactId>
-		<version>2.0.0</version>
+		<version>3.0.0</version>
 		<relativePath>components/extra-parent/pom.xml</relativePath>
 	</parent>
 	
 	<artifactId>extra-modules</artifactId>
-	<version>2.3.0</version>
+	<version>3.0.0</version>
 	<packaging>pom</packaging>
 	<name>extra-modules</name>
 	<description>eXTra Modules</description>


### PR DESCRIPTION
Ich habe den Extra Standard in der Version 1.4 eingespielt und die Datumsklassen auf Local... gewechselt. Die Module kompilieren dann ohne Probleme.

Versionsnummer ist auf 3.0.0 gewechselt.